### PR TITLE
fixing relative path in task topic (determining_correct_wage_level) for image reference

### DIFF
--- a/tasks/t_determining_correct_wage_level.dita
+++ b/tasks/t_determining_correct_wage_level.dita
@@ -17,7 +17,7 @@
         <cmd>determine your law firms calculative method for determining a wage level</cmd>
         <info>law firms may differ in the methods they use but they must meet USCIS determination standards</info>
         <stepxmp>
-          <image href = "wagelevel.jpg"> 
+          <image href = "assets\images\wagelevel.jpg"> 
             <alt>wage level calculative spreadsheet</alt>
           </image>
         </stepxmp>


### PR DESCRIPTION
had to fix relative path for image reference in one of the task topics so it would show up in the ditamap file for lca_data_collection